### PR TITLE
Add registration tests

### DIFF
--- a/apps/backend/jest.config.ts
+++ b/apps/backend/jest.config.ts
@@ -1,0 +1,5 @@
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.ts'],
+};

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "tsc",
     "start": "node dist/server.js",
-    "dev": "ts-node-dev --respawn --transpile-only src/server.ts"
+    "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
+    "test": "jest"
   },
   "dependencies": {
     "bcrypt": "^6.0.0",
@@ -26,6 +27,11 @@
     "@types/prop-types": "^15.7.14",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.4.3"
+    "typescript": "^5.4.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.12",
+    "supertest": "^6.3.4",
+    "@types/supertest": "^2.0.16"
   }
 }

--- a/apps/backend/tests/auth.register.test.ts
+++ b/apps/backend/tests/auth.register.test.ts
@@ -1,0 +1,60 @@
+import request from 'supertest';
+import { createApp } from '../src/app';
+import * as UserModel from '../src/models/User';
+import bcrypt from 'bcrypt';
+
+jest.mock('../src/models/User');
+
+const app = createApp();
+const ENDPOINT = '/api/auth/register';
+
+describe('POST ' + ENDPOINT, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('\u2705 201 | \u0441\u043e\u0437\u0434\u0430\u0451\u0442 \u043d\u043e\u0432\u043e\u0433\u043e \u043f\u043e\u043b\u044c\u0437\u043e\u0432\u0430\u0442\u0435\u043b\u044f', async () => {
+    (UserModel.findUserByEmail as jest.Mock).mockResolvedValue(null);
+    (UserModel.createUser as jest.Mock).mockImplementation(async data => ({
+      id: 'uid-123',
+      ...data,
+    }));
+
+    const payload = {
+      email: 'new@email.com',
+      password: 'Secret123!',
+      name: '\u041d\u043e\u0432\u044b\u0439 \u041a\u043b\u0438\u0435\u043d\u0442',
+    };
+
+    const res = await request(app).post(ENDPOINT).send(payload);
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ ok: true });
+
+    expect(UserModel.findUserByEmail).toHaveBeenCalledWith(payload.email);
+    expect(UserModel.createUser).toHaveBeenCalledTimes(1);
+
+    const saved = (UserModel.createUser as jest.Mock).mock.calls[0][0];
+    expect(saved).toHaveProperty('passwordHash');
+    expect(bcrypt.compareSync(payload.password, saved.passwordHash)).toBe(true);
+  });
+
+  it('\u274c 400 | \u043e\u0442\u0441\u0443\u0442\u0441\u0442\u0432\u0443\u044e\u0442 \u043e\u0431\u044f\u0437\u0430\u0442\u0435\u043b\u044c\u043d\u044b\u0435 \u043f\u043e\u043b\u044f', async () => {
+    const res = await request(app).post(ENDPOINT).send({ email: 'only@mail' });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('\u274c 409 | e-mail \u0443\u0436\u0435 \u0437\u0430\u043d\u044f\u0442', async () => {
+    (UserModel.findUserByEmail as jest.Mock).mockResolvedValue({ id: 'exists' });
+
+    const res = await request(app).post(ENDPOINT).send({
+      email: 'dup@mail.com',
+      password: 'Dup123!',
+      name: '\u0414\u0443\u0431\u043b\u0438\u043a\u0430\u0442',
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toHaveProperty('error', 'email already used');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest config for backend
- add test suite for POST /api/auth/register
- update backend package.json with Jest dependencies and test script

## Testing
- `npm test --workspace=@auto-parts/backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b85c15a083259a23acc6fc92fdef