### PR TITLE
Add backend route tests

### DIFF
--- a/apps/backend/tests/auth.login.test.ts
+++ b/apps/backend/tests/auth.login.test.ts
@@ -1,0 +1,70 @@
+import request from 'supertest';
+import { createApp } from '../src/app';
+import * as UserModel from '../src/models/User';
+import jwt from 'jsonwebtoken';
+import bcrypt from 'bcrypt';
+
+jest.mock('../src/models/User');
+
+const app = createApp();
+const ENDPOINT = '/api/auth/login';
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+describe('POST ' + ENDPOINT, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('\u2705 200 | returns token for valid credentials', async () => {
+    const password = 'Secret1!';
+    const passwordHash = await bcrypt.hash(password, 10);
+    (UserModel.findUserByEmail as jest.Mock).mockResolvedValue({
+      id: 'uid-1',
+      email: 'user@mail.com',
+      passwordHash,
+      role: 'USER',
+      name: 'User One',
+    });
+
+    const res = await request(app).post(ENDPOINT).send({
+      email: 'user@mail.com',
+      password,
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('token');
+    const payload = jwt.verify(res.body.token, JWT_SECRET) as any;
+    expect(payload).toMatchObject({ _id: 'uid-1', role: 'USER', name: 'User One' });
+  });
+
+  it('\u274c 401 | user not found', async () => {
+    (UserModel.findUserByEmail as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(app).post(ENDPOINT).send({
+      email: 'missing@mail.com',
+      password: 'pass',
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('\u274c 401 | wrong password', async () => {
+    const passwordHash = await bcrypt.hash('correct', 10);
+    (UserModel.findUserByEmail as jest.Mock).mockResolvedValue({
+      id: 'uid-2',
+      email: 'user@mail.com',
+      passwordHash,
+      role: 'USER',
+      name: 'User Two',
+    });
+
+    const res = await request(app).post(ENDPOINT).send({
+      email: 'user@mail.com',
+      password: 'wrong',
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toHaveProperty('error');
+  });
+});

--- a/apps/backend/tests/orders.test.ts
+++ b/apps/backend/tests/orders.test.ts
@@ -1,0 +1,91 @@
+import request from 'supertest';
+import { createApp } from '../src/app';
+import * as OrderModel from '../src/models/Order';
+import jwt from 'jsonwebtoken';
+
+jest.mock('../src/models/Order');
+
+const app = createApp();
+const ENDPOINT = '/api/orders';
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+const userToken = jwt.sign({ _id: 'u1', role: 'USER', name: 'User1' }, JWT_SECRET);
+const adminToken = jwt.sign({ _id: 'admin', role: 'ADMIN', name: 'Admin' }, JWT_SECRET);
+
+describe('Orders routes', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('POST ' + ENDPOINT, () => {
+    it('\u2705 201 | creates order for authenticated user', async () => {
+      (OrderModel.createOrder as jest.Mock).mockImplementation(async (data) => ({
+        id: 'o1',
+        ...data,
+      }));
+
+      const payload = { partType: 'Wheel', description: 'desc', images: [] };
+      const res = await request(app)
+        .post(ENDPOINT)
+        .set('Authorization', `Bearer ${userToken}`)
+        .send(payload);
+
+      expect(res.status).toBe(201);
+      expect(OrderModel.createOrder).toHaveBeenCalledWith({
+        userId: 'u1',
+        clientName: 'User1',
+        partType: 'Wheel',
+        description: 'desc',
+        images: [],
+        status: 'NEW',
+      });
+    });
+
+    it('\u274c 401 | no token', async () => {
+      const res = await request(app).post(ENDPOINT).send({});
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe('GET ' + ENDPOINT + '/:id', () => {
+    it('\u2705 200 | owner can read order', async () => {
+      (OrderModel.getOrder as jest.Mock).mockResolvedValue({ id: 'o1', userId: 'u1' });
+
+      const res = await request(app)
+        .get(`${ENDPOINT}/o1`)
+        .set('Authorization', `Bearer ${userToken}`);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('\u2705 200 | admin can read any order', async () => {
+      (OrderModel.getOrder as jest.Mock).mockResolvedValue({ id: 'o1', userId: 'u2' });
+
+      const res = await request(app)
+        .get(`${ENDPOINT}/o1`)
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('\u274c 403 | foreign user forbidden', async () => {
+      (OrderModel.getOrder as jest.Mock).mockResolvedValue({ id: 'o1', userId: 'u2' });
+
+      const res = await request(app)
+        .get(`${ENDPOINT}/o1`)
+        .set('Authorization', `Bearer ${userToken}`);
+
+      expect(res.status).toBe(403);
+    });
+
+    it('\u274c 404 | not found', async () => {
+      (OrderModel.getOrder as jest.Mock).mockResolvedValue(null);
+
+      const res = await request(app)
+        .get(`${ENDPOINT}/missing`)
+        .set('Authorization', `Bearer ${userToken}`);
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/apps/backend/tests/stats.test.ts
+++ b/apps/backend/tests/stats.test.ts
@@ -1,0 +1,56 @@
+import request from 'supertest';
+import { createApp } from '../src/app';
+import jwt from 'jsonwebtoken';
+
+const getMock = jest.fn();
+const collectionMock = jest.fn(() => ({ get: getMock }));
+
+jest.mock('../src/lib/db', () => ({ db: { collection: collectionMock } }));
+
+const app = createApp();
+const ENDPOINT = '/api/stats';
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
+const adminToken = jwt.sign({ _id: 'admin', role: 'ADMIN', name: 'Admin' }, JWT_SECRET);
+const userToken = jwt.sign({ _id: 'u1', role: 'USER', name: 'User' }, JWT_SECRET);
+
+describe('GET ' + ENDPOINT, () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    collectionMock.mockClear();
+  });
+
+  it('\u2705 200 | returns statistics for admin', async () => {
+    const docs = [
+      { data: () => ({ partType: 'A', repairPrice: 10, defectPrice: 5, workHours: 2, clientName: 'Partner' }) },
+      { data: () => ({ partType: 'B', repairPrice: 20, defectPrice: 0, workHours: 0, clientName: 'Partner' }) },
+    ];
+    getMock.mockResolvedValue({ forEach: (cb: any) => docs.forEach(d => cb(d)) });
+
+    const res = await request(app)
+      .get(ENDPOINT)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.partTypeCounts).toEqual({ A: 1, B: 1 });
+    expect(res.body.totals).toEqual({ repairPrice: 30, defectPrice: 5, internalPrice: 2 });
+    expect(res.body.partnerStats.Partner).toEqual({ count: 2, total: 30 });
+  });
+
+  it('\u274c 403 | user is not admin', async () => {
+    const res = await request(app)
+      .get(ENDPOINT)
+      .set('Authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('\u274c 500 | on db error', async () => {
+    getMock.mockRejectedValue(new Error('fail'));
+
+    const res = await request(app)
+      .get(ENDPOINT)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- add login tests
- add CRUD tests for orders
- add admin stats tests

## Testing
- `npm test --workspace=@auto-parts/backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b99f7c588325a01f7aae6673599d