### PR TITLE
Fix Jest mocks and timeouts

### DIFF
--- a/apps/backend/tests/integration.firestore.test.ts
+++ b/apps/backend/tests/integration.firestore.test.ts
@@ -2,6 +2,9 @@ process.env.FIRESTORE_EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST || '12
 process.env.FIREBASE_AUTH_EMULATOR_HOST = process.env.FIREBASE_AUTH_EMULATOR_HOST || '127.0.0.1:9099';
 process.env.GCLOUD_PROJECT = process.env.GCLOUD_PROJECT || 'demo-test';
 
+// Integration tests with the Firestore emulator can take longer
+jest.setTimeout(20_000);
+
 import request from 'supertest';
 import { getFirestore } from 'firebase-admin/firestore';
 import { createApp } from '../src/app';
@@ -43,4 +46,9 @@ describe('Integration with Firestore emulator', () => {
     expect(doc.exists).toBe(true);
     expect(doc.data()?.partType).toBe(orderPayload.partType);
   });
+});
+
+afterAll(async () => {
+  await (app as any).close?.();
+  await db.terminate();
 });

--- a/apps/backend/tests/stats.test.ts
+++ b/apps/backend/tests/stats.test.ts
@@ -1,17 +1,23 @@
+// Declare mocks using var so they are available for the mock factory
+var getMock: jest.Mock;
+var collectionMock: jest.Mock;
+
+// Mock the database module before importing the app
+jest.mock('../src/lib/db', () => {
+  getMock = jest.fn();
+  collectionMock = jest.fn(() => ({ get: getMock }));
+  return { db: { collection: collectionMock } };
+});
+
 import request from 'supertest';
 import { createApp } from '../src/app';
 import jwt from 'jsonwebtoken';
-
-const getMock = jest.fn();
-const collectionMock = jest.fn(() => ({ get: getMock }));
 
 const app = createApp();
 const ENDPOINT = '/api/stats';
 const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret';
 const adminToken = jwt.sign({ _id: 'admin', role: 'ADMIN', name: 'Admin' }, JWT_SECRET);
 const userToken = jwt.sign({ _id: 'u1', role: 'USER', name: 'User' }, JWT_SECRET);
-
-jest.mock('../src/lib/db', () => ({ db: { collection: collectionMock } }));
 
 describe('GET ' + ENDPOINT, () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- fix hoisting issue in `stats.test.ts`
- increase Firestore integration test timeout and close db

## Testing
- `npm run test --workspace=@auto-parts/backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d6d62db48325a9e676d89390cc33