### PR TITLE
Add GitHub Actions workflow for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI – tests & lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  node:
+    runs-on: ubuntu-latest
+    services:
+      firestore:
+        image: ghcr.io/firebase/firebase-emulator:latest
+        ports:
+          - 8080:8080
+        options: >
+          --health-cmd "curl --fail http://localhost:8080 || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 20
+    strategy:
+      matrix:
+        node-version: [18.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run backend tests
+        run: npm run test:e2e -- --ci
+
+#      - name: ESLint
+#        run: npm run lint --workspaces
+
+#      - name: Upload coverage to Codecov
+#        uses: codecov/codecov-action@v4
+#        with:
+#          files: ./apps/backend/coverage/lcov.info
+#          flags: backend
+#          fail_ci_if_error: true


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that sets up Node
- install dependencies using npm workspaces
- run backend tests
- include Firestore emulator service

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6862d917dbc08325a4418c3bf4e9d154